### PR TITLE
Add per-chat support to shared pad plugin

### DIFF
--- a/content.js
+++ b/content.js
@@ -733,3 +733,148 @@
 		});
 	});
 })();
+
+// shared pad extension
+(() => {
+	const API_URL = "https://typingmind-plugin-server-j330.onrender.com/pad";
+	const PANEL_ID = "tm-shared-pad";
+	const PANEL_WIDTH = 420;
+
+	const isChatView = () => {
+		if (location.hash.includes("#chat=")) return true;
+		return (
+			document.querySelector(
+				'[data-element-id="chat-root"], [data-element-id="chat-view"]',
+			) !== null
+		);
+	};
+
+	// Try best-effort chat id extraction. Fallback to "default".
+	function getChatId() {
+		// Hash form: ...#chat=<uuid-or-id>[&...]
+		const m = location.hash.match(/#chat=([^&]+)/);
+		if (m && m[1]) return decodeURIComponent(m[1]);
+
+		// If TypingMind adds data attributes later, look for them:
+		const el = document.querySelector(
+			'[data-element-id="chat-root"], [data-element-id="chat-view"]',
+		);
+		if (el && el.dataset && el.dataset.chatId) return el.dataset.chatId;
+
+		return "default";
+	}
+
+	const mounted = () => document.getElementById(PANEL_ID) != null;
+	const setBodyRightMargin = (px) => {
+		document.body.style.marginRight = px ? `${px}px` : "";
+	};
+
+	const mountPanel = () => {
+		if (mounted()) return;
+
+		if (!document.getElementById(`${PANEL_ID}-style`)) {
+			const style = document.createElement("style");
+			style.id = `${PANEL_ID}-style`;
+			style.textContent = `
+				#${PANEL_ID}{position:fixed;top:0;right:0;height:100vh;width:${PANEL_WIDTH}px;
+					background:#fff;border-left:1px solid #ccc;z-index:2147483647;display:flex;flex-direction:column;font-family:monospace;}
+				#${PANEL_ID} header{padding:6px 8px;border-bottom:1px solid #ccc;}
+				#${PANEL_ID} header button{font-family:monospace;margin-right:6px;}
+				#${PANEL_ID} #status{color:#555;margin-left:6px;}
+				#${PANEL_ID} textarea{flex:1;width:100%;border:none;outline:none;resize:none;font:14px/1.4 monospace;padding:8px;background:#fff;}
+			`;
+			document.head.appendChild(style);
+		}
+
+		const panel = document.createElement("div");
+		panel.id = PANEL_ID;
+		panel.innerHTML = `
+			<header>
+				<button id="tm-pad-refresh">Refresh</button>
+				<button id="tm-pad-save">Save</button>
+				<span id="status"></span>
+			</header>
+			<textarea id="tm-pad-text" spellcheck="false" placeholder="Shared pad…"></textarea>
+		`;
+		document.body.appendChild(panel);
+		setBodyRightMargin(PANEL_WIDTH);
+
+		const $ = (sel) => panel.querySelector(sel);
+		const padEl = $("#tm-pad-text");
+		const statusEl = $("#status");
+		const setStatus = (msg) => (statusEl.textContent = msg || "");
+
+		async function refreshPad() {
+			const chat_id = getChatId();
+			try {
+				setStatus("Loading…");
+				const res = await fetch(API_URL, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ action: "get", chat_id }),
+				});
+				const data = await res.json();
+				padEl.value = data.text || "";
+				setStatus(`Loaded (${chat_id.slice(0, 8)})`);
+			} catch (e) {
+				console.error(e);
+				setStatus("Load failed");
+			}
+		}
+
+		async function savePad() {
+			const chat_id = getChatId();
+			try {
+				setStatus("Saving…");
+				const text = padEl.value;
+				await fetch(API_URL, {
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ action: "set", text, chat_id }),
+				});
+				setStatus(`Saved (${chat_id.slice(0, 8)})`);
+			} catch (e) {
+				console.error(e);
+				setStatus("Save failed");
+			}
+		}
+
+		$("#tm-pad-refresh").addEventListener("click", refreshPad);
+		$("#tm-pad-save").addEventListener("click", savePad);
+
+		// Ctrl/Cmd+S to save
+		window.addEventListener("keydown", (e) => {
+			const isMac = navigator.platform.toUpperCase().includes("MAC");
+			if (
+				(isMac && e.metaKey && e.key === "s") ||
+				(!isMac && e.ctrlKey && e.key === "s")
+			) {
+				e.preventDefault();
+				savePad();
+			}
+		});
+
+		// Initial load
+		refreshPad();
+	};
+
+	const unmountPanel = () => {
+		const el = document.getElementById(PANEL_ID);
+		if (el) el.remove();
+		setBodyRightMargin(0);
+	};
+
+	const reevaluate = () => {
+		if (isChatView()) mountPanel();
+		else unmountPanel();
+	};
+
+	// Initial + route/DOM changes
+	reevaluate();
+	window.addEventListener("hashchange", reevaluate);
+	new MutationObserver(() => {
+		const shouldMount = isChatView();
+		if (shouldMount && !mounted()) mountPanel();
+		else if (!shouldMount && mounted()) unmountPanel();
+	}).observe(document.documentElement, { childList: true, subtree: true });
+})();

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "shared_pad",
+  "title": "Shared Pad",
+  "version": 1,
+  "implementationType": "http",
+  "httpAction": {
+    "method": "POST",
+    "url": "https://typingmind-plugin-server-j330.onrender.com/pad",
+    "hasHeaders": true,
+    "requestHeaders": "{\n  \"Content-Type\": \"application/json\"\n}",
+    "hasBody": true,
+    "requestBodyFormat": "json",
+    "requestBody": "{\n  \"action\": \"{action}\",\n  \"text\": \"{text}\",\n  \"chat_id\": \"{CHAT_ID}\"\n}"
+  },
+  "openaiSpec": {
+    "name": "shared_pad",
+    "description": "Read or overwrite a persistent shared plain-text pad.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "action": { "type": "string", "enum": ["get", "set"] },
+        "text": { "type": "string", "description": "Used when action is set" }
+      },
+      "required": ["action"]
+    }
+  },
+  "outputType": "respond_to_ai"
+}

--- a/src/typingmind_plugin_server/__init__.py
+++ b/src/typingmind_plugin_server/__init__.py
@@ -1,0 +1,70 @@
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from pathlib import Path
+import os, re
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"], allow_credentials=True,
+    allow_methods=["*"], allow_headers=["*"],
+)
+
+BASE_DIR = Path(os.getenv("PAD_DIR", Path.cwd() / "pads"))
+BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+SAFE_ID = re.compile(r"[A-Za-z0-9_\-]+")  # conservative
+
+def sanitize(chat_id: str | None) -> str:
+    if not chat_id:
+        return "default"
+    return chat_id if SAFE_ID.fullmatch(chat_id) else "default"
+
+def file_for(chat_id: str | None) -> Path:
+    cid = sanitize(chat_id)
+    return BASE_DIR / f"{cid}.md"
+
+def read_pad_text(chat_id: str | None) -> str:
+    p = file_for(chat_id)
+    return p.read_text(encoding="utf-8") if p.exists() else ""
+
+def write_pad_text(chat_id: str | None, text: str) -> None:
+    p = file_for(chat_id)
+    p.write_text(text, encoding="utf-8")
+
+class PadPutRequest(BaseModel):
+    text: str
+    chat_id: str | None = None
+
+class PadAction(BaseModel):
+    action: str  # "get" | "set"
+    text: str | None = None
+    chat_id: str | None = None
+
+@app.get("/pad")
+def get_pad() -> dict:
+    # legacy: single shared file
+    return {"text": read_pad_text(None)}
+
+@app.put("/pad")
+def put_pad(req: PadPutRequest) -> dict:
+    # legacy: single shared file
+    write_pad_text(None, req.text)
+    return {"ok": True, "text": req.text}
+
+@app.post("/pad")
+def pad_action(req: PadAction) -> dict:
+    act = req.action.lower().strip()
+    if act == "get":
+        return {"text": read_pad_text(req.chat_id)}
+    if act == "set":
+        if req.text is None:
+            raise HTTPException(status_code=400, detail="text is required for 'set'")
+        write_pad_text(req.chat_id, req.text)
+        return {"ok": True, "text": req.text}
+    raise HTTPException(status_code=400, detail="action must be 'get' or 'set'")
+
+@app.get("/hi")
+def hi() -> dict:
+    return {"ok": True}


### PR DESCRIPTION
Implement per-chat shared pad functionality by enabling chat ID handling for both plugin and extension interactions.

This allows for distinct pads for each conversation. The LLM-initiated plugin calls receive the chat ID via TypingMind's built-in `{CHAT_ID}` injection, while user interactions through the extension panel extract the chat ID directly from the UI (URL hash or DOM).

---
<a href="https://cursor.com/background-agent?bcId=bc-8daa5930-ce46-4436-8163-013d616837e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8daa5930-ce46-4436-8163-013d616837e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

